### PR TITLE
Add the bool indicator to ENABLE_EXAMPLES in the standalone.yml config

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         cmake -G Ninja \
               -D CMAKE_BUILD_TYPE:STRING=RELEASE \
-              -D ENABLE_EXAMPLES=ON \
+              -D ENABLE_EXAMPLES:BOOL=ON \
               -D ENABLE_TESTS:BOOL=ON \
               -B build \
                .


### PR DESCRIPTION
While we were building, the reference config in standalone.yml bothered me since it only had `:BOOL` on one option :stuck_out_tongue: 