### PR TITLE
Avoid using namespace directive in header.

### DIFF
--- a/adapters/sacado/src/function/ROL_Sacado_Constraint_SimOpt.hpp
+++ b/adapters/sacado/src/function/ROL_Sacado_Constraint_SimOpt.hpp
@@ -14,7 +14,7 @@
 #include "ROL_StdVector.hpp"
 #include "ROL_Constraint_SimOpt.hpp"
 
-using namespace ROL;
+namespace ROL {
 
 //! \brief ROL interface wrapper for Sacado SimOpt Constraint
 template<class Real, template<class> class Constr>
@@ -594,4 +594,7 @@ void Sacado_Constraint_SimOpt<Real,Constr>::applyAdjointHessian_22AD(Vector<Scal
 
     }
 }
+
+} // namespace ROL
+
 #endif

--- a/adapters/sacado/src/function/ROL_Sacado_Objective.hpp
+++ b/adapters/sacado/src/function/ROL_Sacado_Objective.hpp
@@ -14,7 +14,7 @@
 #include "ROL_StdVector.hpp"
 #include "ROL_Objective.hpp"
 
-using namespace ROL;
+namespace ROL {
 
 /** \brief Generic objective wrapper class for class that uses Sacado */
 template<class Real, template<class> class Obj>
@@ -151,5 +151,6 @@ void Sacado_Objective<Real,Obj>::hessVecAD( Vector<ScalarT> &hv, const Vector<Sc
     }
 }
 
+} // namespace ROL
 
 #endif

--- a/adapters/sacado/src/function/ROL_Sacado_Objective_SimOpt.hpp
+++ b/adapters/sacado/src/function/ROL_Sacado_Objective_SimOpt.hpp
@@ -14,7 +14,7 @@
 #include "ROL_StdVector.hpp"
 #include "ROL_Objective_SimOpt.hpp"
 
-using namespace ROL;
+namespace ROL {
 
 template <class Real, template<class> class Obj>
 class Sacado_Objective_SimOpt : public Objective_SimOpt<Real> {
@@ -404,6 +404,6 @@ void Sacado_Objective_SimOpt<Real,Obj>::hessVec_22AD(Vector<ScalarT> &hv, const 
 
 }
 
-
+} // namespace ROL
 
 #endif


### PR DESCRIPTION
Hello ROL community! Is this the development repository for ROL? This patch is identical to https://github.com/trilinos/Trilinos/pull/13560, but I figured it makes more sense to request a merge with the development branch.

---

A `using namespace` directive in a header file lead to ambiguity in user code.

In my case, I am experimenting with deal.II and ROL, which lead to name conflicts between `dealii::Vector` and `ROL::Vector`.

In a way related to https://github.com/trilinos/Trilinos/issues/13532.