### PR TITLE
doxygen: Enable searchengine.

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1021,7 +1021,7 @@ FORMULA_FONTSIZE       = 10
 # there is already a search function so this one should typically
 # be disabled.
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES
 
 #---------------------------------------------------------------------------
 # configuration options related to the LaTeX output
@@ -1578,6 +1578,6 @@ MATHJAX_RELPATH        = https://cdn.mathjax.org/mathjax/latest
 # The SEARCHENGINE tag specifies whether or not a search engine should be 
 # used. If set to NO the values of all tags below this one will be ignored.
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES
 
 


### PR DESCRIPTION
This patch will add a search bar to the doxygen generated HTML documentation. This makes navigating the HTML documentation much easier. See also [doxygen documentation on searching](https://www.doxygen.nl/manual/searching.html).

I am not quite sure why you specified with `SEARCHENGINE` tag twice in the `Doxyfile`. The search bar appears after setting both to `YES`. Maybe just the last one counts and would be enough -- but I haven't tried it out.

---

This is how the documentation looks like on my machine (built with doxygen 1.15.0).

<img width="1631" height="1435" alt="image" src="https://github.com/user-attachments/assets/92a5fccf-8667-4ba2-8e1c-887556377695" />