### PR TITLE
Enabled user defined initial guess for ParetoSampler.

### DIFF
--- a/src/mol/ROL_MultiObjectiveFactory.hpp
+++ b/src/mol/ROL_MultiObjectiveFactory.hpp
@@ -264,6 +264,13 @@ public:
     return solution_vec_;
   }
 
+  std::vector<std::string> getObjectiveLabels() const {
+    std::vector<std::string> names;
+    for (auto it = INPUT_obj_.begin(); it != INPUT_obj_.end(); ++it)
+      names.push_back(it->first);
+    return names;
+  }
+
 }; // class MultiObjectiveFactory
 
 }  // namespace ROL

--- a/src/mol/ROL_MultiObjectiveFactory.hpp
+++ b/src/mol/ROL_MultiObjectiveFactory.hpp
@@ -46,11 +46,15 @@ private:
 
   void addConstraintsToProblem(Ptr<Problem<Real>> &problem);
   void computeUtopia(ParameterList &parlist, std::ostream &outStream,
-                     const Ptr<StatusTest<Real>>& status = nullPtr,
-                     bool combineStatus = true);
+                     bool initGuess=false,
+                     const Ptr<Vector<Real>>& x0=nullPtr,
+                     const Ptr<StatusTest<Real>>& status=nullPtr,
+                     bool combineStatus=true);
   void initializeObjectives(ParameterList &parlist, std::ostream &outStream,
-                            const Ptr<StatusTest<Real>>& status = nullPtr,
-                            bool combineStatus = true);
+                            bool initGuess=false,
+                            const Ptr<Vector<Real>>& x0=nullPtr,
+                            const Ptr<StatusTest<Real>>& status=nullPtr,
+                            bool combineStatus=true);
 
 public:
   virtual ~MultiObjectiveFactory() {}
@@ -252,9 +256,11 @@ public:
   */
   const std::vector<ParetoData<Real>>& getEndPoints(ParameterList& parlist,
                                                     std::ostream& outStream=std::cout,
+                                                    bool initGuess=false,
+                                                    const Ptr<Vector<Real>>& x0=nullPtr,
                                                     const Ptr<StatusTest<Real>>& status=nullPtr,
                                                     bool combineStatus=true) {
-    computeUtopia(parlist,outStream,status,combineStatus);
+    computeUtopia(parlist,outStream,initGuess,x0,status,combineStatus);
     return solution_vec_;
   }
 

--- a/src/mol/ROL_MultiObjectiveFactory_Def.hpp
+++ b/src/mol/ROL_MultiObjectiveFactory_Def.hpp
@@ -224,6 +224,8 @@ void MultiObjectiveFactory<Real>::addConstraintsToProblem(Ptr<Problem<Real>> &pr
 
 template<typename Real>
 void MultiObjectiveFactory<Real>::computeUtopia(ParameterList &parlist, std::ostream &outStream,
+                                                bool initGuess,
+                                                const Ptr<Vector<Real>>& x0,
                                                 const Ptr<StatusTest<Real>>& status,
                                                 bool combineStatus) {
   if (values_.size() != cnt_obj_) {
@@ -234,7 +236,7 @@ void MultiObjectiveFactory<Real>::computeUtopia(ParameterList &parlist, std::ost
     unsigned cnt = 0u;
     for (auto it = INPUT_obj_.begin(); it != INPUT_obj_.end(); ++it) {
       // Build single-objective optimization problem
-      auto problem = getScalarProblem(it->first,parlist,outStream);
+      auto problem = getScalarProblem(it->first,parlist,outStream,initGuess,x0);
       problem->finalize(false,true,outStream);
       // Solve single-objective optimization problem
       auto solver = makePtr<Solver<Real>>(problem,parlist);
@@ -257,11 +259,13 @@ void MultiObjectiveFactory<Real>::computeUtopia(ParameterList &parlist, std::ost
 
 template<typename Real>
 void MultiObjectiveFactory<Real>::initializeObjectives(ParameterList &parlist, std::ostream &outStream,
+                                                       bool initGuess,
+                                                       const Ptr<Vector<Real>>& x0,
                                                        const Ptr<StatusTest<Real>>& status,
                                                        bool combineStatus) {
   if (!isObjInit_) {
     const bool normalize = parlist.sublist("Multi-Objective").get("Normalize Objectives",false);
-    computeUtopia(parlist,outStream,status,combineStatus);
+    computeUtopia(parlist,outStream,initGuess,x0,status,combineStatus);
     if (normalize) {
       const Real tol = 1e-2*std::sqrt(ROL_EPSILON<Real>());
       // Compute normalization data
@@ -329,7 +333,7 @@ Ptr<Problem<Real>> MultiObjectiveFactory<Real>::makeScalarProblem(const std::vec
   }
   else {
     // Normalize the objective functions based on utopia points
-    initializeObjectives(parlist,outStream,status,combineStatus);
+    initializeObjectives(parlist,outStream,initGuess,x0,status,combineStatus);
     // Set initial guess
     x = INPUT_xprim_;
     if (initGuess && x0 != nullPtr) {
@@ -348,7 +352,7 @@ Ptr<Problem<Real>> MultiObjectiveFactory<Real>::makeScalarProblem(const std::vec
         break;
       }
       case MOTYPE_NBI: {
-        computeUtopia(parlist,outStream,status,combineStatus);
+        computeUtopia(parlist,outStream,initGuess,x0,status,combineStatus);
         obj = obj_[0];
         nbicon = makePtr<ConstraintNBI<Real>>(obj_,lam,nvalues_);
         nbimul = makePtr<StdVector<Real>>(cnt_obj_-1u);

--- a/src/mol/ROL_ParetoSampler.hpp
+++ b/src/mol/ROL_ParetoSampler.hpp
@@ -26,7 +26,7 @@ public:
   void run(const Ptr<MultiObjectiveFactory<Real>>& factory,
            ParameterList& parlist,
            std::ostream& outStream = std::cout,
-	   const Ptr<StatusTest<Real>> &status = nullPtr,
+           const Ptr<StatusTest<Real>> &status = nullPtr,
            bool combineStatus = true,
            bool reset = false) {
     if (reset) samples_.clear();
@@ -35,7 +35,10 @@ public:
     const int batchid = bman_->batchID();
     const int nbatch = bman_->numBatches();
     // Compute endpoints
-    auto pdsol = factory->getEndPoints(parlist,outStream,status,combineStatus);
+    auto x0 = factory->getOptimizationVector()->clone();
+    x0->set(*factory->getOptimizationVector());
+    const bool initGuess = !parlist.sublist("Multi-Objective").sublist("Pareto Sampler").get("Warm Start",false);
+    auto pdsol = factory->getEndPoints(parlist,outStream,initGuess,x0,status,combineStatus);
     int frac   = nobj / nbatch;
     int rem    = nobj % nbatch;
     int N      = frac + ((batchid < rem) ? 1 : 0);
@@ -44,21 +47,18 @@ public:
     for (int i = 0; i < N; ++i) samples_.push_back(pdsol[offset+i]);
     // Compute random samples
     const int nsamp = parlist.sublist("Multi-Objective").sublist("Pareto Sampler").get("Number of Points",10);
-    const bool initGuess = parlist.sublist("Multi-Objective").sublist("Pareto Sampler").get("Warm Start",false);
     const bool useTrig = parlist.sublist("Multi-Objective").sublist("Pareto Sampler").get("Use Trigonometric Spacing",false);
     if (nobj > 1u && nsamp > 0) {
       Ptr<SampleGenerator<Real>> sampler;
       if (nobj == 2u) sampler = makePtr<Equispaced2dGenerator<Real>>(nsamp,bman_,useTrig);
       else            sampler = makePtr<UniformSimplexGenerator<Real>>(nsamp,nobj,bman_);
-      auto x0 = factory->getOptimizationVector()->clone();
-      x0->set(*factory->getOptimizationVector());
       std::vector<Real> fail(sampler->numMySamples(),zero), lam(nobj);
       Real tottime(0);
       for (int i = 0; i < sampler->numMySamples(); ++i) {
         // Generate simplex sample
         lam = sampler->getMyPoint(i);
         // Solve scalarized problem
-        auto problem = factory->makeScalarProblem(lam,parlist,outStream,initGuess&&(i!=0),x0,status,combineStatus);
+        auto problem = factory->makeScalarProblem(lam,parlist,outStream,initGuess,x0,status,combineStatus);
         //x0->randomize(1.0,2.0);
         problem->finalize(false,true,outStream);
         //problem->check(true,outStream,x0,0.1);
@@ -74,7 +74,6 @@ public:
         auto val = factory->evaluateObjectiveVector(*x);
         ParetoData<Real> pd(x,lam,val,solver->getAlgorithmState()->statusFlag);
         samples_.push_back(pd);
-        x0->set(*x);
       }
       Real nfail = std::reduce(fail.begin(),fail.end()), gtime(0), gfail(0);
       bman_->sumAll(&tottime,&gtime,1);

--- a/src/mol/ROL_ParetoSampler.hpp
+++ b/src/mol/ROL_ParetoSampler.hpp
@@ -18,6 +18,7 @@ class ParetoSampler {
 private:
   const Ptr<BatchManager<Real>> bman_;
   std::vector<ParetoData<Real>> samples_;
+  std::vector<std::string>      labels_;
 
 public:
   ParetoSampler(const Ptr<BatchManager<Real>>& bman = nullPtr)
@@ -35,6 +36,7 @@ public:
     const int batchid = bman_->batchID();
     const int nbatch = bman_->numBatches();
     // Compute endpoints
+    labels_ = factory->getObjectiveLabels();
     auto x0 = factory->getOptimizationVector()->clone();
     x0->set(*factory->getOptimizationVector());
     const bool initGuess = !parlist.sublist("Multi-Objective").sublist("Pareto Sampler").get("Warm Start",false);
@@ -92,7 +94,7 @@ public:
     }
   }
 
-  void print(std::string file) const {
+  void print(std::string file, bool printColumnHeader=false) const {
     // Gather data to root batch
     const unsigned nobj = samples_[0].values.size();
     const unsigned nsamp = samples_.size();
@@ -112,6 +114,11 @@ public:
       std::ofstream os;
       os.open(file);
       os << std::scientific << std::setprecision(15);
+      if (printColumnHeader) {
+        for (unsigned j=0; j<nobj; ++j)
+          os << std::right << std::setw(25) << labels_[j];
+        os << std::endl;
+      }
       for (unsigned i=0; i<nsampg; ++i) {
         for (unsigned j=0; j<nobj; ++j) os << std::right << std::setw(25) << valg[i*nobj+j];
         os << std::endl;

--- a/test/mol/test_01.cpp
+++ b/test/mol/test_01.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[]) {
 
     auto ps = ROL::makePtr<ROL::ParetoSampler<RealT>>();
     ps->run(mof,parlist,*outStream);
-    ps->print("output_01.txt");
+    ps->print("output_01.txt",true);
 
     // Pareto front is given by f1 in [0.01,0.16] or [0.36,0.81]
     // and f2 = (sqrt(f1)-1)^2.  The optimal solutions are

--- a/test/mol/test_01.cpp
+++ b/test/mol/test_01.cpp
@@ -138,9 +138,9 @@ int main(int argc, char *argv[]) {
     parlist.sublist("Step").sublist("Augmented Lagrangian").set("Initial Penalty Parameter",1.0);
     parlist.sublist("Step").sublist("Augmented Lagrangian").set("Use Default Initial Penalty Parameter",false);
     parlist.sublist("Step").sublist("Augmented Lagrangian").set("Use Default Problem Scaling",false);
-    parlist.sublist("Mult-Objective").set("Scalarization Type","Convex Combination");
-    parlist.sublist("Mult-Objective").sublist("Pareto Sampler").set("Number of Points",10);
-    parlist.sublist("Mult-Objective").sublist("Pareto Sampler").set("Warm Start",false);
+    parlist.sublist("Multi-Objective").set("Scalarization Type","Convex Combination");
+    parlist.sublist("Multi-Objective").sublist("Pareto Sampler").set("Number of Points",10);
+    parlist.sublist("Multi-Objective").sublist("Pareto Sampler").set("Warm Start",true);
 
     auto ps = ROL::makePtr<ROL::ParetoSampler<RealT>>();
     ps->run(mof,parlist,*outStream);


### PR DESCRIPTION
The original implementation only used the user-input initial guess for the interior Pareto samples, but not the end points.  This update enables use of the initial guess for the end points.