### PR TITLE
Update README to mention rol-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ cd build
 make
 ```
 
+## Python Interface
+The python pip package rol-python is the official python interface to ROL.
+It is available at https://pypi.org/project/rol-python/ and can be installed via
+```
+pip install rol-python
+```
+
 
 ## Copyright and License
 See COPYRIGHT and LICENSE.


### PR DESCRIPTION
Since there are a lot of different python versions of ROL floating around the internet, linking back to the python package in the README for this repo might help show which version is "official".

I'm imagining this is most useful when somebody visits the ROL website or repository, leaves to look for a python version, and gets confused by the plethora of python ROL packages out there.

Feel free to add tweaks/comments :)