### PR TITLE
PinT stand alone first part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 *.pyc
 __pycache__
 
+# CMake build directories
+build*/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,17 @@ if( STANDALONE_ROL )
   find_package(BLAS REQUIRED)
   find_package(LAPACK REQUIRED)
 
+  # ---- Optional real MPI for the PinT validation target (OFF => serial, unchanged) ----
+  option(ENABLE_MPI "Enable real MPI (native Teuchos-free ROL::GlobalMPISession + PinT)" OFF)
+  if(ENABLE_MPI)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    message(STATUS "ROL: MPI enabled (CXX compiler: ${MPI_CXX_COMPILER})")
+    # adapters/mpi is header-only; expose its include dirs for the example target.
+    set(ROL_MPI_ADAPTER_INCLUDES
+        ${PROJECT_SOURCE_DIR}/adapters/mpi/src/vector
+        ${PROJECT_SOURCE_DIR}/adapters/mpi/src/function)
+  endif()
+
   if(NOT CMAKE_BUILD_TYPE)
       set(CMAKE_BUILD_TYPE RELEASE CACHE STRING "Build type" FORCE)
   endif()
@@ -59,11 +70,18 @@ if( STANDALONE_ROL )
 
   set(SRC ${PROJECT_SOURCE_DIR}/src)
 
-  # Set up compatibility includes (specific directories to avoid conflicts)
+  # Set up compatibility includes (specific directories to avoid conflicts).
+  # real/mpi and simple/mpi BOTH define guard ROL_GlobalMPISession_HPP, so exactly ONE
+  # of them may be on the include path. ENABLE_MPI selects which.
+  if(ENABLE_MPI)
+    set(ROL_MPI_COMPAT_DIR ${SRC}/compatibility/real/mpi)
+  else()
+    set(ROL_MPI_COMPAT_DIR ${SRC}/compatibility/simple/mpi)
+  endif()
   set(ROL_COMPATIBILITY_INCLUDES ${SRC}/compatibility/teuchos/blas
                                  ${SRC}/compatibility/teuchos/la
                                  ${SRC}/compatibility/simple/lapack
-                                 ${SRC}/compatibility/simple/mpi
+                                 ${ROL_MPI_COMPAT_DIR}
                                  ${SRC}/compatibility/simple/parameterlist
                                  ${SRC}/compatibility/std/shared_ptr
                                  ${SRC}/compatibility/teuchos/stacktrace

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -24,6 +24,11 @@ ADD_SUBDIRECTORY(oed)
 ADD_SUBDIRECTORY(lincon-test)
 ADD_SUBDIRECTORY(user-defined-status-test)
 
+# Standalone PinT validation target, only when real MPI is enabled.
+IF(STANDALONE_ROL AND ENABLE_MPI)
+  ADD_SUBDIRECTORY(PinT-standalone)
+ENDIF()
+
 IF(NOT STANDALONE_ROL)
 
 IF(${PACKAGE_NAME}_ENABLE_Sacado)

--- a/example/PinT-standalone/CMakeLists.txt
+++ b/example/PinT-standalone/CMakeLists.txt
@@ -1,0 +1,59 @@
+# example/PinT-standalone/CMakeLists.txt
+# Standalone (no-Trilinos) build of the PinT FD validation test under real MPI.
+# Reached only when STANDALONE_ROL AND ENABLE_MPI (see example/CMakeLists.txt).
+
+set(PINT_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../PinT/parabolic-control)
+
+add_executable(parabolic-control_PinTConstraint_FD_Test
+               ${PINT_SRC_DIR}/PinTConstraint_FD_Test.cpp)
+
+target_include_directories(parabolic-control_PinTConstraint_FD_Test PRIVATE
+                           ${PINT_SRC_DIR}              # dynamicConstraint.hpp
+                           ${ROL_MPI_ADAPTER_INCLUDES}) # adapters/mpi/src/{vector,function}
+
+# rol carries all core/compatibility includes transitively (PUBLIC).
+# MPI::MPI_CXX supplies mpi.h + the MPI libs. Link MPI to the EXE only, never to 'rol'.
+target_link_libraries(parabolic-control_PinTConstraint_FD_Test PRIVATE
+                      rol MPI::MPI_CXX)
+
+# Stage the XML input next to the executable (FD test reads input_ex01.xml).
+# NOTE: COPYONLY runs at configure time; editing the XML needs a reconfigure to re-stage.
+configure_file(${PINT_SRC_DIR}/input_ex01.xml
+               ${CMAKE_CURRENT_BINARY_DIR}/input_ex01.xml COPYONLY)
+
+# ctest: run on 2 ranks via mpirun. PinTCommunicators needs a power-of-two rank count.
+# Test name is hand-chosen (not build-dir-derived, since the source lives elsewhere).
+if(ENABLE_TESTS)
+  add_test(NAME parabolic-control_PinTConstraint_FD_Test
+           COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                   ${MPIEXEC_PREFLAGS}
+                   $<TARGET_FILE:parabolic-control_PinTConstraint_FD_Test>
+                   PrintItAll ${MPIEXEC_POSTFLAGS})
+  set_tests_properties(parabolic-control_PinTConstraint_FD_Test PROPERTIES
+                       PASS_REGULAR_EXPRESSION "TEST PASSED"
+                       PROCESSORS 2)
+endif()
+
+# Manual run (power-of-two ranks only):
+#   mpirun -np 2 ./example/PinT-standalone/parabolic-control_PinTConstraint_FD_Test PrintItAll
+# Expect rank-0 line: 'End Result: TEST PASSED'
+
+# --- Unit tests for the new session + shims (independent of PinTConstraint) ---
+# Linking 'rol' brings the session + shim headers transitively (PUBLIC includes);
+# MPI::MPI_CXX brings mpi.h. No adapter include dirs needed (no PinT headers used).
+add_executable(mpi_session_shim_unittest mpi_session_shim_unittest.cpp)
+target_link_libraries(mpi_session_shim_unittest PRIVATE rol MPI::MPI_CXX)
+
+if(ENABLE_TESTS)
+  # np=1 covers the single-rank session path (getNProc()==1, sum is identity);
+  # np=2 covers genuine multi-rank reductions.
+  foreach(np 1 2)
+    add_test(NAME mpi_session_shim_unittest_np${np}
+             COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np}
+                     ${MPIEXEC_PREFLAGS}
+                     $<TARGET_FILE:mpi_session_shim_unittest> ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(mpi_session_shim_unittest_np${np} PROPERTIES
+                         PASS_REGULAR_EXPRESSION "TEST PASSED"
+                         PROCESSORS ${np})
+  endforeach()
+endif()

--- a/example/PinT-standalone/mpi_session_shim_unittest.cpp
+++ b/example/PinT-standalone/mpi_session_shim_unittest.cpp
@@ -1,0 +1,117 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+// Unit tests for the standalone-ROL additions that enable real-MPI PinT:
+//   (1) src/compatibility/real/mpi/ROL_GlobalMPISession.hpp   (real MPI session)
+//   (2) src/compatibility/teuchos-lite/Teuchos_Time.hpp        (timer + symbol shims)
+// Exercises ONLY the new code in isolation (no PinTConstraint). Run under mpirun
+// (np = 1 or 2). Rank 0 prints "End Result: TEST PASSED" iff every check on every
+// rank passed; the process also exits nonzero on any failure (for ctest).
+
+#include <mpi.h>
+#include <iostream>
+#include <cstddef>
+
+#include "ROL_GlobalMPISession.hpp"   // -> real/mpi under ENABLE_MPI
+#include "ROL_Ptr.hpp"                // ROL::Ptr, makePtr, nullPtr
+#include "Teuchos_Time.hpp"           // Teuchos::as / null, ROL::is_null, StackedTimer
+
+namespace {
+
+int g_fail = 0;
+int g_rank = 0;
+
+// Minimal check macro: counts failures, names the offending rank/line.
+#define CHECK( cond, msg )                                                   \
+  do {                                                                       \
+    if( !(cond) ) {                                                          \
+      ++g_fail;                                                              \
+      std::cerr << "[rank " << g_rank << "] FAIL: " << (msg)                 \
+                << "   (" #cond ", line " << __LINE__ << ")\n";              \
+    }                                                                        \
+  } while( 0 )
+
+// ---- (1) real-MPI ROL::GlobalMPISession -------------------------------------
+void test_session()
+{
+  int mpiRank = -1, mpiSize = -1;
+  MPI_Comm_rank( MPI_COMM_WORLD, &mpiRank );
+  MPI_Comm_size( MPI_COMM_WORLD, &mpiSize );
+
+  int initFlag = 0;
+  MPI_Initialized( &initFlag );
+  CHECK( initFlag != 0, "MPI is initialized after the session constructor" );
+
+  CHECK( ROL::GlobalMPISession::getRank()  == mpiRank, "getRank() matches MPI_Comm_rank" );
+  CHECK( ROL::GlobalMPISession::getNProc() == mpiSize, "getNProc() matches MPI_Comm_size" );
+  CHECK( ROL::GlobalMPISession::getRank() >= 0 &&
+         ROL::GlobalMPISession::getRank() < ROL::GlobalMPISession::getNProc(),
+         "rank is in [0, nproc)" );
+
+  // exactly one process is rank 0 (the distinctness property we care about)
+  const int amRank0 = ( ROL::GlobalMPISession::getRank() == 0 ) ? 1 : 0;
+  CHECK( ROL::GlobalMPISession::sum( amRank0 ) == 1, "exactly one process is rank 0" );
+
+  // collective reductions
+  CHECK( ROL::GlobalMPISession::sum( 1 ) == mpiSize, "sum(1) == nproc (Allreduce)" );
+  CHECK( ROL::GlobalMPISession::sum( mpiRank ) == mpiSize * (mpiSize - 1) / 2,
+         "sum(rank) == n(n-1)/2" );
+
+  ROL::GlobalMPISession::barrier();   // must not hang or crash
+}
+
+// ---- (2) teuchos-lite shims -------------------------------------------------
+void test_shims()
+{
+  // Teuchos::as<Out>(in) == static_cast<Out>(in)
+  CHECK( Teuchos::as<int>( 3.9 )       == 3,              "as<int>(3.9) truncates to 3" );
+  CHECK( Teuchos::as<int>( -2.7 )      == -2,             "as<int>(-2.7) truncates toward zero" );
+  CHECK( Teuchos::as<double>( 5 )      == 5.0,            "as<double>(5) == 5.0" );
+  CHECK( Teuchos::as<std::size_t>( 7 ) == std::size_t(7), "as<size_t>(7) == 7" );
+
+  // Teuchos::null and ROL::is_null on ROL::Ptr (= std::shared_ptr)
+  ROL::Ptr<int> pnull = ROL::nullPtr;
+  ROL::Ptr<int> plive = ROL::makePtr<int>( 42 );
+
+  CHECK( pnull == Teuchos::null, "null Ptr == Teuchos::null" );
+  CHECK( Teuchos::null == pnull, "Teuchos::null == null Ptr (reversed)" );
+  CHECK( plive != Teuchos::null, "live Ptr != Teuchos::null" );
+  CHECK( Teuchos::null != plive, "Teuchos::null != live Ptr (reversed)" );
+  CHECK( ROL::is_null( pnull ),  "is_null(null) is true" );
+  CHECK( !ROL::is_null( plive ), "is_null(live) is false" );
+  CHECK( *plive == 42,           "live Ptr dereferences to its value" );
+
+  // StackedTimer shim: non-null, stable static instance, start/stop are safe no-ops
+  ROL::Ptr<Teuchos::StackedTimer> t1 = Teuchos::TimeMonitor::getStackedTimer();
+  ROL::Ptr<Teuchos::StackedTimer> t2 = Teuchos::TimeMonitor::getStackedTimer();
+  CHECK( t1 != Teuchos::null,  "getStackedTimer() returns non-null" );
+  CHECK( t1.get() == t2.get(), "getStackedTimer() returns the same instance" );
+  t1->start( "unit" );
+  t1->stop( "unit" );          // compiles and does not crash
+}
+
+} // namespace
+
+int main( int argc, char** argv )
+{
+  ROL::GlobalMPISession session( &argc, &argv );
+  g_rank = ROL::GlobalMPISession::getRank();
+
+  test_session();
+  test_shims();
+
+  // Agree on a single verdict across all ranks (also exercises sum()).
+  const int globalFail = ROL::GlobalMPISession::sum( g_fail );
+
+  if( g_rank == 0 ) {
+    if( globalFail == 0 ) { std::cout << "End Result: TEST PASSED\n"; }
+    else { std::cout << "End Result: TEST FAILED (" << globalFail << " checks failed)\n"; }
+  }
+  return ( globalFail == 0 ) ? 0 : 1;
+}

--- a/src/compatibility/real/mpi/ROL_GlobalMPISession.hpp
+++ b/src/compatibility/real/mpi/ROL_GlobalMPISession.hpp
@@ -1,0 +1,83 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef ROL_GlobalMPISession_HPP
+#define ROL_GlobalMPISession_HPP
+
+// Native, Teuchos-free real-MPI ROL::GlobalMPISession. Drop-in replacement for the
+// serial stub at src/compatibility/simple/mpi/ROL_GlobalMPISession.hpp. It reuses the
+// SAME include guard on purpose: exactly one of compatibility/{real,simple}/mpi may be
+// on the -I path (the root CMakeLists.txt selects it via ENABLE_MPI). Whichever appears
+// first wins; the other is guard-suppressed.
+
+#include <ostream>
+#include <mpi.h>
+
+namespace ROL {
+
+struct GlobalMPISession {
+
+  // Accepts the existing call sites:
+  //   GlobalMPISession(&argc,&argv);      and   GlobalMPISession(&argc,&argv,0);
+  // The 3rd arg mirrors Teuchos' optional rank-0 ostream*; accepted and ignored.
+  GlobalMPISession( int* argc = nullptr,
+                    char*** argv = nullptr,
+                    std::ostream* /*out*/ = nullptr )
+  {
+    int alreadyInit = 0;
+    MPI_Initialized( &alreadyInit );
+    if( !alreadyInit ) { MPI_Init( argc, argv ); ownInit_ = true; }
+  }
+
+  ~GlobalMPISession()
+  {
+    if( ownInit_ ) {
+      int finalized = 0;
+      MPI_Finalized( &finalized );
+      if( !finalized ) MPI_Finalize();
+    }
+  }
+
+  GlobalMPISession( const GlobalMPISession& ) = delete;
+  GlobalMPISession& operator=( const GlobalMPISession& ) = delete;
+
+  static void abort() { MPI_Abort( MPI_COMM_WORLD, -1 ); }
+
+  static void barrier() { if( initialized() ) MPI_Barrier( MPI_COMM_WORLD ); }
+
+  static int getNProc() {
+    if( !initialized() ) return 1;
+    int n = 1; MPI_Comm_size( MPI_COMM_WORLD, &n ); return n;
+  }
+
+  // TRUE rank (serial stub wrongly returned the constant 1).
+  static int getRank() {
+    if( !initialized() ) return 0;
+    int r = 0; MPI_Comm_rank( MPI_COMM_WORLD, &r ); return r;
+  }
+
+  static int sum( int localVal ) {
+    if( !initialized() ) return localVal;
+    int g = 0; MPI_Allreduce( &localVal, &g, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD );
+    return g;
+  }
+
+private:
+  static bool initialized() {
+    int flag = 0; MPI_Initialized( &flag );
+    if( !flag ) return false;
+    int fin = 0; MPI_Finalized( &fin );
+    return !fin;
+  }
+  bool ownInit_ = false;
+};
+
+} // namespace ROL
+
+#endif // ROL_GlobalMPISession_HPP

--- a/src/compatibility/teuchos-lite/Teuchos_StackedTimer.hpp
+++ b/src/compatibility/teuchos-lite/Teuchos_StackedTimer.hpp
@@ -1,0 +1,14 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef TEUCHOS_STACKEDTIMER_HPP
+#define TEUCHOS_STACKEDTIMER_HPP
+// Standalone shim: see Teuchos_Time.hpp in this directory for the no-op StackedTimer.
+#include "Teuchos_Time.hpp"
+#endif // TEUCHOS_STACKEDTIMER_HPP

--- a/src/compatibility/teuchos-lite/Teuchos_Time.hpp
+++ b/src/compatibility/teuchos-lite/Teuchos_Time.hpp
@@ -1,0 +1,69 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+// Standalone teuchos-lite shim: no-op timers + the few Teuchos/ROL symbols the
+// ROL PinT adapter headers use that are otherwise absent without full Trilinos.
+// This file is #included (by name) from ROL_PinTVector.hpp, ROL_PinTConstraint.hpp,
+// and ROL_PinTHierarchy.hpp, BEFORE their first use of Teuchos::as / Teuchos::null /
+// ROL::is_null / TEUCHOS_ASSERT, so defining them here reaches every call site and
+// keeps the adapter headers byte-identical to upstream Trilinos ROL.
+#ifndef TEUCHOS_TIME_HPP
+#define TEUCHOS_TIME_HPP
+
+#include <ostream>
+#include <string>
+#include <memory>
+
+#include "ROL_Ptr.hpp"        // ROL::Ptr, ROL::makePtr, ROL::nullPtr
+#include "Teuchos_Assert.hpp" // TEUCHOS_ASSERT (not transitively reachable otherwise)
+
+namespace Teuchos {
+
+// ---- no-op stacked timer (return value is dereferenced via ->, so it must be live) ----
+class StackedTimer {
+public:
+  void start( const std::string& ) {}
+  void stop ( const std::string& ) {}
+  void report( std::ostream& )     {} // unused by adapters/mpi/src; kept for parity
+};
+
+struct TimeMonitor {
+  static ROL::Ptr<StackedTimer> getStackedTimer() {
+    static ROL::Ptr<StackedTimer> t = ROL::makePtr<StackedTimer>();
+    return t;
+  }
+};
+
+// ---- Teuchos::as<Out>(in)  (only instantiated as as<int>(size_type)) ----
+template<class Out, class In>
+inline Out as( const In& x ) { return static_cast<Out>(x); }
+
+// ---- Teuchos::null sentinel, comparable to ROL::Ptr (== std::shared_ptr) ----
+struct ENull {};
+static const ENull null = ENull{};
+
+template<class T>
+inline bool operator==( const std::shared_ptr<T>& p, ENull ) { return p == nullptr; }
+template<class T>
+inline bool operator!=( const std::shared_ptr<T>& p, ENull ) { return p != nullptr; }
+template<class T>
+inline bool operator==( ENull, const std::shared_ptr<T>& p ) { return p == nullptr; }
+template<class T>
+inline bool operator!=( ENull, const std::shared_ptr<T>& p ) { return p != nullptr; }
+
+} // namespace Teuchos
+
+namespace ROL {
+// bare is_null(...) in ROL_PinTConstraint.hpp:749 resolves here (call site is inside
+// namespace ROL). ROL_Ptr.hpp ships only is_nullPtr; provide the is_null spelling used.
+template<class T>
+inline bool is_null( const Ptr<T>& x ) { return x == nullPtr; }
+} // namespace ROL
+
+#endif // TEUCHOS_TIME_HPP

--- a/src/compatibility/teuchos-lite/Teuchos_TimeMonitor.hpp
+++ b/src/compatibility/teuchos-lite/Teuchos_TimeMonitor.hpp
@@ -1,0 +1,15 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef TEUCHOS_TIMEMONITOR_HPP
+#define TEUCHOS_TIMEMONITOR_HPP
+// Standalone shim: the real Teuchos timing stack is provided by Teuchos_Time.hpp
+// in this directory (no-op StackedTimer + TimeMonitor::getStackedTimer).
+#include "Teuchos_Time.hpp"
+#endif // TEUCHOS_TIMEMONITOR_HPP


### PR DESCRIPTION
This is my first go at the PinT. My goal here is enable the Pint vectors and MPI. Below I have a more detailed explanation, I hope to follow up on that with a second push that has the actual PinT examples. Let me know what you think Denis.

1) Added a new file  src/compatibility/real/mpi/ROL_GlobalMPISession.hpp

The build picks to use that or 
src/compatibility/simple/mpi/ROL_GlobalMPISession.hpp.
start MPI, ask my rank, combine across ranks, stop MPI" available as a tidy object that cleans up after itself.

2) Added a new file src/compatibility/teuchos-lite/Teuchos_Time.hpp 

I created a mini-Teuchos folder, so I do not have to change the main codes in PinT. There is a Teuchos_Time, which is essentially a timer.

3) Added a files in src/compatibility/teuchos-lite/Teuchos_TimeMonitor.hppTecuhos_StackedTimer.hppI need those for the timer glue I created in 2) maybe there is a better workaround.

4) Changed one of the original files
CMakeLists.txt
I just added an on off switch for the MPI

5) Changed one of the original files
examples/CMakeLists.txt
added one line to create the folders

6) Created a file 
example/PinT-standalone/CMakeLists.txt 
This is where the MPI uses the flags and we create the runnables 

7) Created a file 
mpi_session_shim_unittest.cpp
This is a unit test to see if MPI works.